### PR TITLE
Enhance release workflow with version checks and syntax cleanup

### DIFF
--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -3,6 +3,9 @@ name: Check for updates
 on:
   schedule:
     - cron: "0 0 * * *"
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release Build
 
 on:
   release:
-    types: published
+    types:
+      - published
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * 1'  # Every Monday at 3 AM UTC


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow triggers to improve release handling and scheduling consistency. The main changes involve adjusting how the workflows respond to release events and scheduled triggers.

**Workflow trigger improvements:**

* [`.github/workflows/check-update.yml`](diffhunk://#diff-73e01aa089166ed4072a6514cf296ae75467892706c0520a8480f5c4c4bab9a5R6-R8): Added the `release` event (specifically for `published` releases) as a trigger, so this workflow now runs both on a schedule and whenever a release is published.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L5-R6): Reformatted the `release` event trigger to explicitly specify a list for the `types` field (now using `- published`), improving YAML consistency and clarity.